### PR TITLE
Optimize data loading per role

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -97,7 +97,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         if (!error && userData) {
           setCurrentUser(userData);
           setIsAuthenticated(true);
-          await loadInitialData();
+          await loadInitialData(userData);
         } else {
           console.error("Error fetching user data:", error);
           logout();

--- a/src/context/app/authOperations.ts
+++ b/src/context/app/authOperations.ts
@@ -7,7 +7,7 @@ import { User } from '@/types';
 export function useAuthOperations(
   setCurrentUser: React.Dispatch<React.SetStateAction<User | null>>,
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>,
-  loadInitialData: () => Promise<void>,
+  loadInitialData: (user?: User | null) => Promise<void>,
   users: User[]
 ) {
   // Login function implementation
@@ -33,7 +33,7 @@ export function useAuthOperations(
         if (!userError && userData) {
           setCurrentUser(userData);
           setIsAuthenticated(true);
-          await loadInitialData();
+          await loadInitialData(userData);
           return true;
         } else {
           console.error("User not found in our database", userError);
@@ -55,14 +55,15 @@ export function useAuthOperations(
               console.error("Error storing user in database:", insertError);
               return false;
             } else {
-              setCurrentUser({
+              const newUser = {
                 id: data.user.id,
                 name: contextUser.name,
                 email: contextUser.email,
                 role: contextUser.role
-              });
+              };
+              setCurrentUser(newUser);
               setIsAuthenticated(true);
-              await loadInitialData();
+              await loadInitialData(newUser);
               return true;
             }
           } else {
@@ -80,14 +81,15 @@ export function useAuthOperations(
               console.error("Error creating default user:", insertError);
               return false;
             } else {
-              setCurrentUser({
+              const newUser = {
                 id: data.user.id,
                 name: email.split('@')[0],
                 email: email,
                 role: 'worker'
-              });
+              };
+              setCurrentUser(newUser);
               setIsAuthenticated(true);
-              await loadInitialData();
+              await loadInitialData(newUser);
               return true;
             }
           }

--- a/src/context/app/types.ts
+++ b/src/context/app/types.ts
@@ -33,6 +33,6 @@ export interface AppContextProps {
   calculateTaskProgress: (task: Task) => number;
   generateReport: (taskId: string, message: string) => Promise<void>;
   getReports: () => Report[];
-  loadInitialData: () => Promise<void>;
+  loadInitialData: (user?: User | null) => Promise<void>;
   dataLoaded: boolean;
 }

--- a/src/pages/InProgress.tsx
+++ b/src/pages/InProgress.tsx
@@ -12,7 +12,7 @@ const InProgress = () => {
     if (currentUser && !dataLoaded && !isLoading) {
       console.log("Loading initial data from InProgress page");
       setIsLoading(true);
-      loadInitialData().finally(() => {
+      loadInitialData(currentUser).finally(() => {
         setIsLoading(false);
       });
     }


### PR DESCRIPTION
## Summary
- load only tasks/reports relevant to the logged in user
- remove heavy realtime reloads from the index page
- adapt auth and context hooks to pass current user when loading data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849b35b13c08326b7a9924d4c7c6bab